### PR TITLE
Clarify the permissions of the SUPPORT role in the proto

### DIFF
--- a/ovgs.pb.go
+++ b/ovgs.pb.go
@@ -39,7 +39,8 @@ type UserRole int32
 
 const (
 	UserRole_USER_ROLE_UNSPECIFIED UserRole = 0
-	// Internal to the service
+	// Internal to the service, used by the vendor to invoke support related operations
+	// Read write to everything
 	UserRole_USER_ROLE_SUPPORT UserRole = 1
 	// Read write to everything
 	UserRole_USER_ROLE_ADMIN UserRole = 2
@@ -227,13 +228,13 @@ func (x *User) GetUserRole() UserRole {
 	return UserRole_USER_ROLE_UNSPECIFIED
 }
 
-// A component uniquely identifies a part for which a voucher can be issued
+// A component uniquely identifies a part which can be queried by this service
 type Component struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// ien is the vendor's IANA Enterprise Number. 30065 is Arista Networks's ien.
+	// ien is the vendor's IANA Enterprise Number.
 	Ien          string `protobuf:"bytes,1,opt,name=ien,proto3" json:"ien,omitempty"`
 	SerialNumber string `protobuf:"bytes,2,opt,name=serial_number,json=serialNumber,proto3" json:"serial_number,omitempty"`
 }

--- a/ovgs.proto
+++ b/ovgs.proto
@@ -51,7 +51,8 @@ option go_package = "github.com/aristanetworks/ownership-voucher-grpc/ovgs";
 
 enum UserRole {
   USER_ROLE_UNSPECIFIED = 0;
-  // Internal to the service
+  // Internal to the service, used by the vendor to invoke support related operations
+  // Read write to everything
   USER_ROLE_SUPPORT = 1;
   // Read write to everything
   USER_ROLE_ADMIN = 2;
@@ -87,9 +88,9 @@ message User {
   UserRole user_role = 4;  
 }
 
-// A component uniquely identifies a part for which a voucher can be issued
+// A component uniquely identifies a part which can be queried by this service
 message Component {
-   // ien is the vendor's IANA Enterprise Number. 30065 is Arista Networks's ien.
+    // ien is the vendor's IANA Enterprise Number.
     string ien = 1;
     string serial_number = 2;
 }


### PR DESCRIPTION
- Document the permissions of the  SUPPORT role
- It may not make sense to issue vouchers against some components, but ovgs still allows for querying details about them ( GetSerial can be used to fetch the mac address). Change the description to accommodate this.